### PR TITLE
add switchtype and switchspacing information to keyboard.csv

### DIFF
--- a/keyboards.csv
+++ b/keyboards.csv
@@ -1,66 +1,66 @@
-id,nKeysMin,nKeysMax,name,include,hasNumRow,hasFuncRow,numRows,colStagger,rowStagger,rotaryEncoder,wireless,onePiece,diy,prebuilt,url_source,url_store
-3w6,36,36,3w6,1,0,0,3,Aggressive,0,0,0,0,1,0,https://github.com/weteor/3W6,NA
-absolem,36,36,Absolem,1,0,0,3,Aggressive,0,0,0,1,1,0,https://zealot.hu/absolem/,NA
-arch36,36,36,Arch 36,1,0,0,3,Aggressive,0,0,0,0,1,0,https://github.com/obosob/arch-36-case,NA
-atreus,42,42,Atreus,1,0,0,4,Aggressive,0,0,0,1,1,1,https://github.com/technomancy/atreus,https://falba.tech/customize-your-keyboard/
-balbuzard,36,36,Balbuzard,1,0,0,3,Agressive,0,0,0,1,1,0,https://github.com/brow/balbuzard,
-claw44,44,44,Claw44,1,0,0,3,Aggressive,0,0,0,0,1,0,https://github.com/yfuku/claw44,NA
-corne,36,42,Corne,1,0,0,3,Moderate,0,0,0,0,1,0,https://github.com/foostan/crkbd,NA
-corneish_zen,36,42,Corne-ish Zen,1,0,0,3,Moderate,0,0,1,0,1,0,https://www.thingiverse.com/thing:4698210,https://lowprokb.ca/products/corne-ish-zen-2
-darknight,60,60,Darknight,1,1,0,5,None,0,0,0,0,1,0,https://github.com/macroxue/keyboard-diy,NA
-dracuLad,34,36,DracuLad,1,0,0,3,Aggressive,0,1,0,0,1,0,https://github.com/MangoIV/dracuLad/,NA
-dygma_raise,68,68,Dygma Raise,1,1,0,5,None,1,0,0,0,0,1,NA,https://www.dygma.com/
-elephant42,42,42,Elephant 42,1,0,0,3,Aggressive,0,0,0,0,1,0,https://github.com/illness072/elephant42,NA
-ergodash1,66,68,Ergodash 1,1,1,0,5,Moderate,0,0,0,0,1,0,https://github.com/omkbd/ErgoDash,https://falba.tech/customize-your-keyboard/
-ergodash2,68,70,Ergodash 2,1,1,0,5,Moderate,0,0,0,0,1,0,https://github.com/omkbd/ErgoDash,https://falba.tech/customize-your-keyboard/
-ergodox,76,80,Ergodox,1,1,0,5,Moderate,0,0,0,0,1,1,https://github.com/Ergodox-io/ErgoDox,https://ergodox-ez.com/
-ergoslab,52,52,Ergoslab,1,0,0,5,Aggressive,0,0,0,0,1,0,https://github.com/tomsaleeba/ergoslab/,NA
-ergotravel,53,54,Ergotravel,1,0,0,4,Moderate,0,0,0,0,1,0,https://github.com/jpconstantineau/ErgoTravel,NA
-ferris,34,34,Ferris,1,0,0,3,Aggressive,0,0,0,0,1,0,https://github.com/pierrechevalier83/ferris/,NA
-fifi,36,36,Fifi,1,0,0,3,Aggressive,0,0,0,0,1,0,https://github.com/raychengy/fifi_split_keeb,NA
-freestyle_edge_pro,95,95,Kinesis Freestyle Edge,1,1,1,6,None,1,0,0,0,0,1,NA,https://gaming.kinesis-ergo.com/edge/
-georgi,30,30,Georgi,1,0,0,2,Moderate,0,0,0,0,1,1,NA,https://www.gboards.ca/
-gergo,46,50,Gergo,1,0,0,3,Moderate,0,0,0,0,1,1,NA,https://www.gboards.ca/
-gergoplex,36,36,Gergoplex,1,0,0,3,Moderate,0,0,0,0,1,1,NA,https://www.gboards.ca/
-ginny,10,10,Ginny,1,0,0,1,Moderate,0,0,0,0,1,0,NA,https://www.gboards.ca/
-interphase,66,66,Interphase,1,1,0,5,Aggressive,0,0,1,0,1,0,https://github.com/Durburz/interphase,NA
-iris,54,56,Iris,1,1,0,4,Moderate,0,1,0,0,1,0,https://github.com/keebio/iris-case,https://keeb.io/products/iris-keyboard-split-ergonomic-keyboard
-jklp,36,36,jklp,1,0,0,4,Agressive,0,0,0,1,1,0,https://github.com/brow/jklp,
-keyboardio_model01,64,64,Keyboardio Model01,1,1,0,4,Aggressive,0,0,0,0,0,1,https://github.com/keyboardio,https://shop.keyboard.io/products/model-01-keyboard
-keyseebee,44,44,Keyseebee,1,0,0,3,Aggressive,0,0,0,0,1,0,https://github.com/TeXitoi/keyseebee,NA
-kimiko,58,60,Kimiko,1,1,0,4,Aggressive,0,1,0,0,1,0,https://github.com/Keycapsss/Kimiko,https://keycapsss.com/keyboard-parts/pcb/139/kimiko-split-keyboard-pcb
-kyria,46,50,Kyria,1,0,0,3,Aggressive,0,1,0,0,1,1,https://github.com/splitkb/kyria,https://splitkb.com/
-lily58,58,58,Lily58,1,1,0,4,Moderate,0,0,0,0,1,0,https://github.com/kata0510/Lily58,NA
-microdox,36,36,Microdox,1,0,0,3,Moderate,0,0,0,0,1,0,https://github.com/boardsource/microdox-goodies,https://boardsource.xyz/store/5f2e7e4a2902de7151494f92
-minidox,36,36,Minidox,1,0,0,3,Moderate,0,0,0,0,1,1,https://github.com/dotdash32/Cases/tree/master/Minidox,https://falba.tech/customize-your-keyboard/
-mitosis,46,46,Mitosis,1,0,0,3,Aggressive,0,0,1,0,1,0,https://github.com/joric/mitosis-hardware/tree/joric_kicad,NA
-moonlander,72,72,Moonlander,1,1,0,5,Moderate,0,0,0,0,0,1,NA,https://www.zsa.io/moonlander/
-nyquist,60,60,Nyquist,1,1,0,5,None,0,0,0,0,1,0,https://github.com/keebio/nyquist-case,https://keeb.io/products/nyquist-keyboard
-pluckey,64,68,Pluckey,1,1,0,5,Moderate,0,1,0,0,1,0,https://github.com/floookay/pluckey,NA
-pteron,38,56,Pteron,1,1,0,4,Agressive,0,0,0,1,1,0,https://github.com/FSund/pteron-keyboard,NA
-pteron36,36,36,Pteron 36,1,0,0,3,Agressive,0,0,0,0,1,0,https://github.com/harshitgoel96/pteron36-split-keyboard,NA
-quefrency_rev1,63,72,Quefrency R1,1,1,0,5,None,1,0,0,0,1,0,https://github.com/keebio/quefrency-case,https://keeb.io/products/quefrency-60-65-split-staggered-keyboard
-quefrency_rev2,78,83,Quefrency R2,1,1,0,5,None,1,1,0,0,1,0,https://github.com/keebio/quefrency-case,https://keeb.io/collections/split-keyboard-parts/products/quefrency-rev-2-60-65-split-staggered-keyboard
-redox,70,70,Redox,1,1,0,5,Moderate,0,0,1,0,1,1,https://github.com/mattdibi/redox-keyboard,https://falba.tech/customize-your-keyboard/
-reviung39,39,39,Reviung 39,1,0,0,3,Moderate,0,0,0,1,1,0,https://github.com/gtips/reviung,NA
-reviung41,41,41,Reviung 41,1,0,0,3,Moderate,0,0,0,1,1,0,https://github.com/gtips/reviung,NA
-rhymestone,40,40,Rhymestone,1,0,0,4,None,0,0,0,0,1,0,https://github.com/marksard/Keyboards/tree/master/rhymestone,https://boardsource.xyz/store/5ecb6aee86879c9a0c22da89
-sinc,94,100,Sinc,1,1,1,6,None,1,1,0,0,1,0,https://github.com/keebio/sinc-case,https://keeb.io/products/sinc-split-staggered-75-keyboard
-sofle_v1,58,58,Sofle V1,1,1,0,4,Moderate,0,1,0,0,1,0,https://github.com/josefadamcik/SofleKeyboard,NA
-sofle_v2,58,58,Sofle V2,1,1,0,4,Aggressive,0,1,0,0,1,0,https://github.com/josefadamcik/SofleKeyboard,NA
-sol2,64,68,Sol2,1,1,0,5,None,0,0,0,0,1,0,https://github.com/RGBKB/Keyboard-files/tree/master/Sol,https://www.rgbkb.net/collections/sol-2
-splay46,46,46,Splay 46,1,0,0,3,Aggressive,0,0,0,0,1,0,https://github.com/kobababa/Splay46,NA
-squiggle,34,38,Squiggle,1,0,0,3,Aggressive,0,0,0,0,1,0,https://github.com/ibnuda/Squiggle,NA
-torn,44,46,Torn,1,0,0,3,Moderate,0,1,0,0,1,0,https://github.com/rtitmuss/torn,NA
-uhk_ansi,63,66,Ultimate Hacking KeyBoard,1,1,1,5,None,1,0,0,0,0,1,NA,https://ultimatehackingkeyboard.com/
-viterbi,68,70,Viterbi,1,1,0,5,None,0,0,0,0,1,0,https://github.com/keebio/viterbi-case,https://keeb.io/products/viterbi-keyboard-pcbs-5x7-70-split-ortholinear
-xenon,44,54,Xenon,1,0,0,3,Aggressive,0,0,0,0,1,0,https://github.com/narinari/xenon-keyboard,NA
-yaemk,62,68,YAEMK,1,1,0,1,Agressive,0,1,0,0,1,0,https://karlk90.github.io/yaemk-split-kb/,NA
-zen2,64,68,Zen 2,1,1,0,5,None,0,0,0,0,1,0,https://github.com/RGBKB/Keyboard-files/tree/master/Zen,https://www.rgbkb.net/products/zen-keyboard?variant=14061935624253
-zodiark,68,70,Zodiark,1,1,0,5,Agressive,0,1,0,0,1,0,https://github.com/Aleblazer/Zodiark-Case,https://www.splitlogic.xyz/
-zygomorph,56,60,Zygomorph,1,1,0,5,None,0,0,0,0,1,0,https://github.com/RGBKB/Keyboard-files/tree/master/Zygomorph,https://www.rgbkb.net/products/zygomorph-keyboard?variant=12821537587261
-apoptosis,44,44,Apoptosis,0,0,0,3,Agressive,0,0,1,0,1,0,https://github.com/pseudoku/Apoptosis,NA
-chimera52,52,52,Chimera,0,1,0,3,Agressive,0,0,1,0,1,0,https://github.com/GlenPickle/Chimera,NA
-kbo_5000,92,96,KBO-5000,0,1,1,6,None,1,1,0,0,1,0,https://github.com/keebio/kbo-5000-case,https://keeb.io/collections/kbo-5000-split-staggered-80-keyboard/products/kbo-5000-split-staggered-80-keyboard
-matias_ergo_pro,86,86,Matias Ergo Pro,0,1,1,6,None,1,0,0,0,0,1,NA,https://matias.ca/ergopro/pc/
-pinky4,64,64,Pinky4,0,1,0,4,Moderate,0,0,0,0,1,0,https://github.com/tamanishi/Pinky4,NA
+id,nKeysMin,nKeysMax,name,include,hasNumRow,hasFuncRow,numRows,colStagger,rowStagger,rotaryEncoder,wireless,onePiece,diy,prebuilt,mxCompatible,chocV1,chocV2,mxSpacing,chocSpacing,url_source,url_store
+3w6,36,36,3w6,1,0,0,3,Aggressive,0,0,0,0,1,0,0,1,0,0,1,https://github.com/weteor/3W6,NA
+absolem,36,36,Absolem,1,0,0,3,Aggressive,0,0,0,1,1,0,1,1,1,1,0,https://zealot.hu/absolem/,NA
+arch36,36,36,Arch 36,1,0,0,3,Aggressive,0,0,0,0,1,0,1,0,0,1,0,https://github.com/obosob/arch-36-case,NA
+atreus,42,42,Atreus,1,0,0,4,Aggressive,0,0,0,1,1,1,1,0,0,1,0,https://github.com/technomancy/atreus,https://falba.tech/customize-your-keyboard/
+balbuzard,36,36,Balbuzard,1,0,0,3,Agressive,0,0,0,1,1,0,1,1,1,1,0,https://github.com/brow/balbuzard,
+claw44,44,44,Claw44,1,0,0,3,Aggressive,0,0,0,0,1,0,1,0,0,1,0,https://github.com/yfuku/claw44,NA
+corne,36,42,Corne,1,0,0,3,Moderate,0,0,0,0,1,0,1,1,1,1,0,https://github.com/foostan/crkbd,NA
+corneish_zen,36,42,Corne-ish Zen,1,0,0,3,Moderate,0,0,1,0,1,0,0,1,0,0,1,https://www.thingiverse.com/thing:4698210,https://lowprokb.ca/products/corne-ish-zen-2
+darknight,60,60,Darknight,1,1,0,5,None,0,0,0,0,1,0,1,1,1,1,0,https://github.com/macroxue/keyboard-diy,NA
+dracuLad,34,36,DracuLad,1,0,0,3,Aggressive,0,1,0,0,1,0,1,1,0,1,0,https://github.com/MangoIV/dracuLad/,NA
+dygma_raise,68,68,Dygma Raise,1,1,0,5,None,1,0,0,0,0,1,1,0,0,1,0,NA,https://www.dygma.com/
+elephant42,42,42,Elephant 42,1,0,0,3,Aggressive,0,0,0,0,1,0,1,0,0,1,0,https://github.com/illness072/elephant42,NA
+ergodash1,66,68,Ergodash 1,1,1,0,5,Moderate,0,0,0,0,1,0,1,0,0,1,0,https://github.com/omkbd/ErgoDash,https://falba.tech/customize-your-keyboard/
+ergodash2,68,70,Ergodash 2,1,1,0,5,Moderate,0,0,0,0,1,0,1,0,0,1,0,https://github.com/omkbd/ErgoDash,https://falba.tech/customize-your-keyboard/
+ergodox,76,80,Ergodox,1,1,0,5,Moderate,0,0,0,0,1,1,1,0,0,1,0,https://github.com/Ergodox-io/ErgoDox,https://ergodox-ez.com/
+ergoslab,52,52,Ergoslab,1,0,0,5,Aggressive,0,0,0,0,1,0,1,0,0,1,0,https://github.com/tomsaleeba/ergoslab/,NA
+ergotravel,53,54,Ergotravel,1,0,0,4,Moderate,0,0,0,0,1,0,1,0,0,1,0,https://github.com/jpconstantineau/ErgoTravel,NA
+ferris,34,34,Ferris,1,0,0,3,Aggressive,0,0,0,0,1,0,1,1,1,1,1,https://github.com/pierrechevalier83/ferris/,NA
+fifi,36,36,Fifi,1,0,0,3,Aggressive,0,0,0,0,1,0,1,0,0,1,0,https://github.com/raychengy/fifi_split_keeb,NA
+freestyle_edge_pro,95,95,Kinesis Freestyle Edge,1,1,1,6,None,1,0,0,0,0,1,1,0,0,1,0,NA,https://gaming.kinesis-ergo.com/edge/
+georgi,30,30,Georgi,1,0,0,2,Moderate,0,0,0,0,1,1,0,1,0,0,1,NA,https://www.gboards.ca/
+gergo,46,50,Gergo,1,0,0,3,Moderate,0,0,0,0,1,1,1,0,0,1,0,NA,https://www.gboards.ca/
+gergoplex,36,36,Gergoplex,1,0,0,3,Moderate,0,0,0,0,1,1,0,1,0,0,1,NA,https://www.gboards.ca/
+ginny,10,10,Ginny,1,0,0,1,Moderate,0,0,0,0,1,0,0,1,0,1,0,NA,https://www.gboards.ca/
+interphase,66,66,Interphase,1,1,0,5,Aggressive,0,0,1,0,1,0,1,0,0,1,0,https://github.com/Durburz/interphase,NA
+iris,54,56,Iris,1,1,0,4,Moderate,0,1,0,0,1,0,1,1,1,1,0,https://github.com/keebio/iris-case,https://keeb.io/products/iris-keyboard-split-ergonomic-keyboard
+jklp,36,36,jklp,1,0,0,4,Agressive,0,0,0,1,1,0,1,1,1,1,0,https://github.com/brow/jklp,
+keyboardio_model01,64,64,Keyboardio Model01,1,1,0,4,Aggressive,0,0,0,0,0,1,1,0,0,1,0,https://github.com/keyboardio,https://shop.keyboard.io/products/model-01-keyboard
+keyseebee,44,44,Keyseebee,1,0,0,3,Aggressive,0,0,0,0,1,0,1,1,0,1,0,https://github.com/TeXitoi/keyseebee,NA
+kimiko,58,60,Kimiko,1,1,0,4,Aggressive,0,1,0,0,1,0,1,0,0,1,0,https://github.com/Keycapsss/Kimiko,https://keycapsss.com/keyboard-parts/pcb/139/kimiko-split-keyboard-pcb
+kyria,46,50,Kyria,1,0,0,3,Aggressive,0,1,0,0,1,1,1,1,1,1,0,https://github.com/splitkb/kyria,https://splitkb.com/
+lily58,58,58,Lily58,1,1,0,4,Moderate,0,0,0,0,1,0,1,1,0,1,0,https://github.com/kata0510/Lily58,NA
+microdox,36,36,Microdox,1,0,0,3,Moderate,0,0,0,0,1,0,1,1,1,1,0,https://github.com/boardsource/microdox-goodies,https://boardsource.xyz/store/5f2e7e4a2902de7151494f92
+minidox,36,36,Minidox,1,0,0,3,Moderate,0,0,0,0,1,1,1,0,0,1,0,https://github.com/dotdash32/Cases/tree/master/Minidox,https://falba.tech/customize-your-keyboard/
+mitosis,46,46,Mitosis,1,0,0,3,Aggressive,0,0,1,0,1,0,1,0,0,1,0,https://github.com/joric/mitosis-hardware/tree/joric_kicad,NA
+moonlander,72,72,Moonlander,1,1,0,5,Moderate,0,0,0,0,0,1,1,0,0,1,0,NA,https://www.zsa.io/moonlander/
+nyquist,60,60,Nyquist,1,1,0,5,None,0,0,0,0,1,0,1,1,1,1,0,https://github.com/keebio/nyquist-case,https://keeb.io/products/nyquist-keyboard
+pluckey,64,68,Pluckey,1,1,0,5,Moderate,0,1,0,0,1,0,1,1,0,1,0,https://github.com/floookay/pluckey,NA
+pteron,38,56,Pteron,1,1,0,4,Agressive,0,0,0,1,1,0,1,1,1,1,0,https://github.com/FSund/pteron-keyboard,NA
+pteron36,36,36,Pteron 36,1,0,0,3,Agressive,0,0,0,0,1,0,1,1,1,1,1,https://github.com/harshitgoel96/pteron36-split-keyboard,NA
+quefrency_rev1,63,72,Quefrency R1,1,1,0,5,None,1,0,0,0,1,0,1,0,0,1,0,https://github.com/keebio/quefrency-case,https://keeb.io/products/quefrency-60-65-split-staggered-keyboard
+quefrency_rev2,78,83,Quefrency R2,1,1,0,5,None,1,1,0,0,1,0,1,0,0,1,0,https://github.com/keebio/quefrency-case,https://keeb.io/collections/split-keyboard-parts/products/quefrency-rev-2-60-65-split-staggered-keyboard
+redox,70,70,Redox,1,1,0,5,Moderate,0,0,1,0,1,1,1,0,0,1,0,https://github.com/mattdibi/redox-keyboard,https://falba.tech/customize-your-keyboard/
+reviung39,39,39,Reviung 39,1,0,0,3,Moderate,0,0,0,1,1,0,1,0,0,1,0,https://github.com/gtips/reviung,NA
+reviung41,41,41,Reviung 41,1,0,0,3,Moderate,0,0,0,1,1,0,1,0,0,1,0,https://github.com/gtips/reviung,NA
+rhymestone,40,40,Rhymestone,1,0,0,4,None,0,0,0,0,1,0,1,0,0,1,0,https://github.com/marksard/Keyboards/tree/master/rhymestone,https://boardsource.xyz/store/5ecb6aee86879c9a0c22da89
+sinc,94,100,Sinc,1,1,1,6,None,1,1,0,0,1,0,1,0,0,1,0,https://github.com/keebio/sinc-case,https://keeb.io/products/sinc-split-staggered-75-keyboard
+sofle_v1,58,58,Sofle V1,1,1,0,4,Moderate,0,1,0,0,1,0,1,1,0,1,0,https://github.com/josefadamcik/SofleKeyboard,NA
+sofle_v2,58,58,Sofle V2,1,1,0,4,Aggressive,0,1,0,0,1,0,1,0,0,1,0,https://github.com/josefadamcik/SofleKeyboard,NA
+sol2,64,68,Sol2,1,1,0,5,None,0,0,0,0,1,0,1,1,0,1,0,https://github.com/RGBKB/Keyboard-files/tree/master/Sol,https://www.rgbkb.net/collections/sol-2
+splay46,46,46,Splay 46,1,0,0,3,Aggressive,0,0,0,0,1,0,1,0,0,1,0,https://github.com/kobababa/Splay46,NA
+squiggle,34,38,Squiggle,1,0,0,3,Aggressive,0,0,0,0,1,0,1,1,0,1,0,https://github.com/ibnuda/Squiggle,NA
+torn,44,46,Torn,1,0,0,3,Moderate,0,1,0,0,1,0,1,1,0,1,0,https://github.com/rtitmuss/torn,NA
+uhk_ansi,63,66,Ultimate Hacking KeyBoard,1,1,1,5,None,1,0,0,0,0,1,1,0,0,1,0,NA,https://ultimatehackingkeyboard.com/
+viterbi,68,70,Viterbi,1,1,0,5,None,0,0,0,0,1,0,1,0,0,1,0,https://github.com/keebio/viterbi-case,https://keeb.io/products/viterbi-keyboard-pcbs-5x7-70-split-ortholinear
+xenon,44,54,Xenon,1,0,0,3,Aggressive,0,0,0,0,1,0,1,1,0,1,0,https://github.com/narinari/xenon-keyboard,NA
+yaemk,62,68,YAEMK,1,1,0,1,Agressive,0,1,0,0,1,0,1,0,0,1,0,https://karlk90.github.io/yaemk-split-kb/,NA
+zen2,64,68,Zen 2,1,1,0,5,None,0,0,0,0,1,0,1,1,0,1,0,https://github.com/RGBKB/Keyboard-files/tree/master/Zen,https://www.rgbkb.net/products/zen-keyboard?variant=14061935624253
+zodiark,68,70,Zodiark,1,1,0,5,Agressive,0,1,0,0,1,0,1,0,0,1,0,https://github.com/Aleblazer/Zodiark-Case,https://www.splitlogic.xyz/
+zygomorph,56,60,Zygomorph,1,1,0,5,None,0,0,0,0,1,0,1,1,0,1,0,https://github.com/RGBKB/Keyboard-files/tree/master/Zygomorph,https://www.rgbkb.net/products/zygomorph-keyboard?variant=12821537587261
+apoptosis,44,44,Apoptosis,0,0,0,3,Agressive,0,0,1,0,1,0,1,0,0,1,0,https://github.com/pseudoku/Apoptosis,NA
+chimera52,52,52,Chimera,0,1,0,3,Agressive,0,0,1,0,1,0,1,0,0,1,0,https://github.com/GlenPickle/Chimera,NA
+kbo_5000,92,96,KBO-5000,0,1,1,6,None,1,1,0,0,1,0,1,0,0,1,0,https://github.com/keebio/kbo-5000-case,https://keeb.io/collections/kbo-5000-split-staggered-80-keyboard/products/kbo-5000-split-staggered-80-keyboard
+matias_ergo_pro,86,86,Matias Ergo Pro,0,1,1,6,None,1,0,0,0,0,1,0,0,0,1,0,NA,https://matias.ca/ergopro/pc/
+pinky4,64,64,Pinky4,0,1,0,4,Moderate,0,0,0,0,1,0,1,0,0,1,0,https://github.com/tamanishi/Pinky4,NA


### PR DESCRIPTION
This should help resolving issue #55 .

I've broadened the scope a bit two, since I think the requested filters need also information on the switch spacing.
I've added the following columns to keyboard.csv:

mxCompatible - board supports mx-style switches (was cherry in your suggestion)
chocV1 - board supports Kailh Choc V1 (PG1350) switches
chocV2 - board supports Kailh Choc V2 (PG1353) switches 

mxSpacing - board supports 19x19mm switch spacing for MX and/or Choc V2
chocSpacing - board supports 18x17mm switch spacing for Choc V1