### PR TITLE
Add Ability For Multi-page PDF -- 1 Keyboard Per Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The app is hosted for [free online](https://jhelvy.shinyapps.io/splitkbcompare/)
 ```
 install.packages(c(
     "shiny", "DT", "dplyr", "shinythemes", "shinyWidgets", "magick", "readr",
-    "RColorBrewer", "markdown"
+    "RColorBrewer", "markdown", "rmarkdown"
 ))
 ```
 

--- a/app.R
+++ b/app.R
@@ -78,6 +78,10 @@ ui <- navbarPage(title = "",
                     actionButton(
                         inputId = "reset",
                         label   = "Reset")),
+                div(style="display: inline-block;vertical-align:top;",
+                    actionButton(
+                        inputId = "selectAll",
+                        label   = "Select All Filtered")),
                 # Main keyboard selection options
                 prettyCheckboxGroup(
                     inputId   = "keyboard",
@@ -220,6 +224,20 @@ server <- function(input, output, session) {
             session  = session,
             inputId  = "availability",
             selected = "All"
+        )
+    }, ignoreInit = TRUE)
+
+    # Control Select All button
+    observeEvent(input$selectAll, {
+        # Select all displayed (filtered) keyboards
+        # Identical to filtering step but also set selected=`choices list`.
+        keyboardNames <- getFilteredKeyboardNames(input, keyboards)
+        updatePrettyCheckboxGroup(
+            session = session,
+            inputId = "keyboard",
+            choices = keyboardNames,
+            selected = keyboardNames,
+            prettyOptions = list(shape = "curve", outline = TRUE, animation = "pulse")
         )
     }, ignoreInit = TRUE)
 

--- a/code/functions.R
+++ b/code/functions.R
@@ -201,7 +201,17 @@ filterAvailability <- function(input, keyboards, temp) {
 
 # Functions for creating the merged image overlays
 getImageOverlayColor <- function(ids, images, palette) {
-    colors <- c(palette[1:length(ids)], "white")
+    # Don't want to select an index past palette's length
+    # So modulo the required indices around palette's length
+    # (Note this will select the same color multiple times but it gets so hectic
+    # it's unnoticable)
+    colors <- c(palette[
+                  # Modulo works nicely with 0-indexed not 1 indexed indices, so
+                  # convert -> 0-indexed and then back
+                  ((seq_along(ids) - 1) %% length(palette)) + 1
+                ],
+                "white")
+
     ids <- c(ids, "border")
     i <- 1
     overlay <- images$scale_black

--- a/code/printLetter.Rmd
+++ b/code/printLetter.Rmd
@@ -12,7 +12,11 @@ header-includes:
 params:
   path: NA
 ---
-
-```{r, echo=FALSE, out.width="100%", warning=FALSE, message=FALSE}
-image_read(params$path)
+```{r, echo=FALSE, results="asis", warning=FALSE, message=FALSE, out.width="100%"}
+# Known issue for knitr include_graphics: https://stackoverflow.com/questions/51268623/insert-images-using-knitrinclude-graphics-in-a-for-loop
+# Can't image_read outside top-level. So cheat and output markdown format image
+# inclusion and use result="asis"
+for(path in params$path){
+  cat(paste0("![](", path, ")"), "\n")
+}
 ```

--- a/todo.txt
+++ b/todo.txt
@@ -14,3 +14,5 @@ Features:
 - Add "open image in new tab" button
 - Add single instead of multiple select? (#39)
 - Add "mirror" image button (#17)
+- Github action/CI to automatically generate mega-PDF with all keyboards for easy printing
+   - Generate one pdf per keyboard with nice URL for easy hot linking by original repos


### PR DESCRIPTION
Hi,

I've been enjoying using this to decide which keyboard to build, thanks for building it :-)

The one thing which was missing for me was the ability to print a set of keyboards individually so I could 'try' them out and decide. Sort of like #39. These all get towards that goal (although maybe other small tweaks which might be useful).

The UI tweaks are shown in [1], I added a "Select All Filtered" button (5d81900) to make it easier to select a lot of keyboards at once (which also uncovered an index overflow in the palette selection) and two new "Separate Page" buttons which exports one keyboard per page (25f54bc). I could also imagine keeping only the two export pdf buttons and converting them into a drop down for "Separate" or "All Together"

Finally, I'm happy to help with this but similar to the hotlinking in #54, I thought this led to some possible related features (3e45b08) where a mega pdf is generated with one page per keyboard for people who wanted to compare quickly/print a selection. Also a hot link to a pdf for each keyboard might make it even easier for keyboard creators to link to an easy printing page [like the kyria](https://docs.splitkb.com/hc/en-us/articles/360010627159-Can-I-try-the-Kyria-before-I-buy-)

Per the implenetation:

- I had to change the way the images are rendered by rmarkdown but it doesn't seem to impact scaling. I printed off a set and they were also 5cm accurate
- imagemagick does slow down when rendering many keyboards overlayed at once and it also slows down the rmarkdown export for many pages. I don't know how much of a concern it is for shinyapps hosting but this might encourage people to use up a higher server load. Maybe caching? Limit overlay rendering at 10 keyboards?
- The way I changed it, it also allows printing arbitrary groups of keyboards on a single page (not just all-overlapping or each to a singe page). It might be nice to print two to a page or something, but I couldn't make a nice UI for it

[1]
![image](https://user-images.githubusercontent.com/1739784/140248423-02ed07ad-ef67-4a70-bde7-81de40d0505d.png)