### PR TITLE
Add mirror button for display and printing. Solves #17.

### DIFF
--- a/app.R
+++ b/app.R
@@ -111,6 +111,10 @@ ui <- navbarPage(title = "",
                     outputId = "printA4Sep",
                     label    = "A4 Separate Pages",
                     sepPages = TRUE),
+                checkboxGroupButtons(
+                    inputId = "mirrorImage",
+                    label = "",
+                    choices = "Mirror Image"),
                 # Add custom styling
                 tags$head(tags$style(HTML(paste(readLines(
                     file.path("includes", "style.css")), collapse=" ")))),
@@ -271,6 +275,8 @@ server <- function(input, output, session) {
     output$layout <- renderImage({
         # Create the color image overlay
         overlayColor <- makeImageOverlay(images, palette, color = TRUE)
+        # Mirror when button is active. Non active button returns NULL.
+        if(!is.null(input$mirrorImage)) overlayColor <- image_flop(overlayColor)
         # Define the path to the image
         tmpImagePathColor <- overlayColor %>%
             image_write(tempfile(fileext = 'png'), format = 'png')
@@ -331,6 +337,9 @@ server <- function(input, output, session) {
                     # Create the black and white image overlay
                     overlayBw <- makeImageOverlay(images, palette,
                                                   color = FALSE, IDs = gp)
+                    
+                    # Mirror when button is active. Non active button returns NULL.
+                    if(!is.null(input$mirrorImage)) overlayBw <- image_flop(overlayBw)
 
                     # Define the path to the image
                     tmpImagePathBw <- overlayBw %>%


### PR DESCRIPTION
Hi,

I added a simple mirror button to address the feature as requested in #17. 

I wasn't able to fix all the mirrored labels yet. Do you make the overlay images by hand in the .ai file? Some possible options:
- Make a second .ai file for the left sides. Unfortunately this would lead to a lot of redundancy for all the symmetric keyboards.
- Seperate the labels/scale from the images and combine them later via R. Unfortunately this would only be easy for the symmetric keyboards. The unsymmetric ones would still need two images.

I'll have to think about this some more, but for now a simple mirror as implemented in this commit could be enough.

I'm happy to make further changes if you'd already thought of another way to solve this issue.