### PR TITLE
Datatable filter switch

### DIFF
--- a/server.R
+++ b/server.R
@@ -4,13 +4,15 @@ server <- function(input, output, session) {
     # Add pdf folder as ResourcePath
     addResourcePath(prefix = "pdf", directoryPath = file.path("images", "pdf"))
 
+    # Find filtered keyboard names
+    fKeyboardNames <- reactive({getFilteredKeyboardNames(input, keyboards)})
+    
     # Filter keyboard options based on filter options
     observe({
-        keyboardNames <- getFilteredKeyboardNames(input, keyboards)
         updatePrettyCheckboxGroup(
             session = session,
             inputId = "keyboard",
-            choices = keyboardNames,
+            choices = fKeyboardNames(),
             prettyOptions = list(shape = "curve", outline = TRUE, animation = "pulse")
         )
     })
@@ -18,8 +20,9 @@ server <- function(input, output, session) {
     # Make filtered datatable
     fKeyboardsDT <- reactive({
         if (input$filterDT) {
-            keyboardNames <- getFilteredKeyboardNames(input, keyboards)
-            keyboardNamesOrg <- gsub(" \\(.*)", "", keyboardNames)
+            # Get names of the keyboards instead of the display names that
+            # include key counts
+            keyboardNamesOrg <- keyboards$name[keyboards$nameKeys %in% fKeyboardNames()]
             keyboardsDT[keyboardsDT$Name %in% keyboardNamesOrg, ]
         }
     })
@@ -98,12 +101,11 @@ server <- function(input, output, session) {
         {
             # Select all displayed (filtered) keyboards
             # Identical to filtering step but also set selected=`choices list`.
-            keyboardNames <- getFilteredKeyboardNames(input, keyboards)
             updatePrettyCheckboxGroup(
                 session = session,
                 inputId = "keyboard",
-                choices = keyboardNames,
-                selected = keyboardNames,
+                choices = fKeyboardNames(),
+                selected = fKeyboardNames(),
                 prettyOptions = list(shape = "curve", outline = TRUE, animation = "pulse")
             )
         },

--- a/server.R
+++ b/server.R
@@ -14,7 +14,16 @@ server <- function(input, output, session) {
             prettyOptions = list(shape = "curve", outline = TRUE, animation = "pulse")
         )
     })
-
+    
+    # Make filtered datatable
+    fKeyboardsDT <- reactive({
+        if (input$filterDT) {
+            keyboardNames <- getFilteredKeyboardNames(input, keyboards)
+            keyboardNamesOrg <- gsub(" \\(.*)", "", keyboardNames)
+            keyboardsDT[keyboardsDT$Name %in% keyboardNamesOrg, ]
+        }
+    })
+    
     # Set initial starting layout based on url parameter
     observeEvent("",
         {
@@ -41,7 +50,7 @@ server <- function(input, output, session) {
     # Render keyboard table on "Keyboards" page
     output$keyboardsDT <- DT::renderDataTable({
         DT::datatable(
-            keyboardsDT,
+            if (input$filterDT) fKeyboardsDT() else keyboardsDT,
             escape = FALSE,
             style = "bootstrap",
             rownames = FALSE,

--- a/ui.R
+++ b/ui.R
@@ -94,6 +94,12 @@ ui <- navbarPage(
         icon = icon(name = "keyboard", lib = "font-awesome"),
         mainPanel(
             width = 7,
+            switchInput(
+                inputId = "filterDT",
+                onLabel = "Apply filters",
+                offLabel = "Show all",
+                size = "mini"
+            ),
             DT::dataTableOutput("keyboardsDT"),
             br(),
             # Insert footer


### PR DESCRIPTION
Hi,

I tried to implement a switch on the Keyboards pane that applies all active filters from the compare pane. By default this functionality is not active.

After writing it I saw that `getFilteredKeyboardNames` gets called three times in `server.R`, it should be a bit more efficient (and cleaner) to treat is as a `reactive` value.

If you have any ideas for the placement or the type of switch I'm happy to implement. I think it's okay as of now but it could always be nicer.