### PR TITLE
Fix pdf printing on separate pages for A4 format

### DIFF
--- a/code/printA4.Rmd
+++ b/code/printA4.Rmd
@@ -14,6 +14,11 @@ params:
   path: NA
 ---
 
-```{r, echo=FALSE, out.width="100%", warning=FALSE, message=FALSE}
-image_read(params$path)
+```{r, echo=FALSE, results="asis", warning=FALSE, message=FALSE, out.width="100%"}
+# Known issue for knitr include_graphics: https://stackoverflow.com/questions/51268623/insert-images-using-knitrinclude-graphics-in-a-for-loop
+# Can't image_read outside top-level. So cheat and output markdown format image
+# inclusion and use result="asis"
+for(path in params$path){
+  cat(paste0("![](", path, ")"), "\n")
+}
 ```


### PR DESCRIPTION
Printing the keyboards on separate pages is broken when using A4 format as noted in #78 and #98.

The reason is that when printing on separate pages was implemented in #64, it required a knitr workaround that was only added for letter format. This PR adds the same workaround now also for A4 format.

Closes #98 

